### PR TITLE
Bumps hyperapp version to 0.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "rimraf": "^2.6.2",
     "rollup": "^0.50.0",
     "swig": "^1.4.2",
-    "uglify-js": "2.7.5"
+    "uglify-js": "2.7.5",
+    "hyperapp": "^0.14.0"
   },
   "peerDependencies": {
     "hyperapp": "^0.14.0"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "uglify-js": "2.7.5"
   },
   "dependencies": {
-    "hyperapp": "^0.12.1"
+    "hyperapp": "^0.14.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "test": "jest --no-cache",
     "compile": "rimraf dist && swig render -j vars.json src/html.* -o dist",
-    "bundle": "rollup -n hyperappHtml -f umd -i dist/html.js -o dist/html.dist.js",
+    "bundle": "rollup -n hyperappHtml -f umd -i dist/html.js -g hyperapp:hyperapp -o dist/html.dist.js",
     "minify": "uglifyjs dist/html.dist.js -o dist/html.dist.js --mangle --compress warnings=false --pure-funcs=Object.defineProperty -p relative --source-map dist/html.js.map",
     "build": "npm run compile && npm run bundle && npm run minify",
     "prepublish": "npm run build",
@@ -45,7 +45,7 @@
     "swig": "^1.4.2",
     "uglify-js": "2.7.5"
   },
-  "dependencies": {
+  "peerDependencies": {
     "hyperapp": "^0.14.0"
   }
 }


### PR DESCRIPTION
Addressing https://github.com/hyperapp/html/issues/2 and https://github.com/hyperapp/hyperapp/issues/402

> Hyperapp `0.14.0` modified the VNode API from {tag,data,children} to {tag,props,children}.

Hyperapp is a dependency of @hyperapp/html, the mismatch in versions (and API) broke compatibility with `0.14.0`. This fixes that.

Anyone needing to use hyperapp version less than `0.14.0` for whatever reason, should stick their @hyperapp/html version at `0.2.0` for compatibility. Everyone else should use `latest`.